### PR TITLE
Adicionar CRUD de etiquetas

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ import 'package:flutter/material.dart';
 import 'package:notorious_note/pages/home_page.dart';
 import 'package:provider/provider.dart';
 
-import 'pages/main_page.dart';
+import 'pages/notes_page.dart';
 import 'services/database.dart';
 import 'services/sqlite_database.dart';
 

--- a/lib/models/note_model.dart
+++ b/lib/models/note_model.dart
@@ -20,6 +20,8 @@
 
 import 'package:flutter/material.dart';
 
+import 'tag_model.dart';
+
 class NoteModel {
   final int id;
   final String title;
@@ -27,12 +29,15 @@ class NoteModel {
   final String creation;
   final int archived;
 
+  final TagModel tag;
+
   NoteModel(
       {this.id,
       @required this.title,
       @required this.content,
       this.creation,
-      this.archived})
+      this.archived,
+      this.tag})
       : assert(title != null || content != null);
 
   Map<String, dynamic> toMap() {
@@ -61,5 +66,22 @@ class NoteModel {
         content: content,
         creation: creation,
         archived: archived);
+  }
+
+  NoteModel copyWith({
+    int id,
+    String title,
+    String content,
+    String creation,
+    int archived,
+    TagModel tag,
+  }) {
+    return NoteModel(
+        id: id ?? this.id,
+        title: title ?? this.title,
+        content: content ?? this.content,
+        creation: creation ?? this.creation,
+        archived: archived ?? this.archived,
+        tag: tag ?? this.tag);
   }
 }

--- a/lib/models/tag_model.dart
+++ b/lib/models/tag_model.dart
@@ -24,9 +24,8 @@ class TagModel {
   final int id;
   final String name;
 
-  TagModel({@required this.id, @required this.name})
-      : assert(id != null),
-        assert(name != null);
+  TagModel({this.id, @required this.name})
+      : assert(name != null);
 
   Map<String, dynamic> toMap() {
     return {"id": this.id, "name": this.name};

--- a/lib/pages/archived_notes_page.dart
+++ b/lib/pages/archived_notes_page.dart
@@ -25,10 +25,10 @@ import '../models/note_model.dart';
 import '../services/database.dart';
 import 'note_editor.dart';
 
-class NotesPage extends StatefulWidget {
+class ArchivedNotesPage extends StatefulWidget {
   final Database database;
 
-  const NotesPage({Key key, this.database}) : super(key: key);
+  const ArchivedNotesPage({Key key, this.database}) : super(key: key);
 
   static Future<void> show(BuildContext context, {Database database}) async {
     database = (database == null)
@@ -36,17 +36,17 @@ class NotesPage extends StatefulWidget {
         : database;
     await Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => NotesPage(database: database),
+        builder: (context) => ArchivedNotesPage(database: database),
         fullscreenDialog: true,
       ),
     );
   }
 
   @override
-  _NotesPageState createState() => _NotesPageState();
+  _ArchivedNotesPageState createState() => _ArchivedNotesPageState();
 }
 
-class _NotesPageState extends State<NotesPage> {
+class _ArchivedNotesPageState extends State<ArchivedNotesPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -67,14 +67,14 @@ class _NotesPageState extends State<NotesPage> {
 
   Widget _buildContents(BuildContext context) {
     return FutureBuilder<List<NoteModel>>(
-      future: widget.database.listNotes(),
+      future: widget.database.listArchivedNotes(),
       builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
         if (snapshot.hasData) {
           final List<NoteModel> items = snapshot.data;
           if (items.isNotEmpty) {
             return ListView.separated(
                 itemBuilder: (context, index) => Card(
-                        child: InkWell(
+                    child: InkWell(
                       splashColor: Colors.grey,
                       onTap: () => print("Note ${items[index].id} selected"),
                       child: Column(
@@ -108,14 +108,14 @@ class _NotesPageState extends State<NotesPage> {
                       ),
                     )),
                 separatorBuilder: (context, index) => Divider(
-                      height: 0.5,
-                    ),
+                  height: 0.5,
+                ),
                 itemCount: items.length);
           } else {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[Text("No notes"), Text("Please add a note")],
+                children: <Widget>[Text("No notes are archived")],
               ),
             );
           }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:notorious_note/pages/main_page.dart';
+import 'package:notorious_note/pages/notes_page.dart';
+import 'package:notorious_note/pages/tags_page.dart';
 import 'package:notorious_note/pages/test_page.dart';
 import 'package:notorious_note/services/database.dart';
 import 'package:provider/provider.dart';
@@ -41,18 +42,20 @@ class _HomePageState extends State<HomePage> {
   void _buildPageList(BuildContext context) {
     _pageArray = [
       BottomNavigatorPageItem(
-          pageObject:
-              MainPage(database: Provider.of<Database>(context, listen: false)),
+          pageObject: NotesPage(
+              database: Provider.of<Database>(context, listen: false)),
           pageAppBar: AppBar(
             title: Text("Notes"),
           ),
           pageBarItem:
               BottomNavigationBarItem(icon: Icon(Icons.note), label: "Notes")),
       BottomNavigatorPageItem(
-          pageObject: TestPage(),
-          pageAppBar: AppBar(title: Text("Test Page")),
+          pageObject: TagsPage(
+            database: Provider.of<Database>(context, listen: false),
+          ),
+          pageAppBar: AppBar(title: Text("Tags")),
           pageBarItem: BottomNavigationBarItem(
-              icon: Icon(Icons.access_alarm_outlined), label: "Test")),
+          icon: Icon(Icons.tag), label: "Tags")),
     ];
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:notorious_note/pages/archived_notes_page.dart';
 import 'package:notorious_note/pages/notes_page.dart';
 import 'package:notorious_note/pages/tags_page.dart';
 import 'package:notorious_note/pages/test_page.dart';
@@ -49,6 +50,13 @@ class _HomePageState extends State<HomePage> {
           ),
           pageBarItem:
               BottomNavigationBarItem(icon: Icon(Icons.note), label: "Notes")),
+      BottomNavigatorPageItem(
+          pageObject: ArchivedNotesPage(
+            database: Provider.of<Database>(context, listen: false),
+          ),
+          pageAppBar: AppBar(title: Text("Archived Notes")),
+          pageBarItem: BottomNavigationBarItem(
+              icon: Icon(Icons.archive), label: "Archived Notes")),
       BottomNavigatorPageItem(
           pageObject: TagsPage(
             database: Provider.of<Database>(context, listen: false),

--- a/lib/pages/note_editor.dart
+++ b/lib/pages/note_editor.dart
@@ -19,6 +19,7 @@
 */
 
 import 'package:flutter/material.dart';
+import 'package:notorious_note/models/tag_model.dart';
 import 'package:provider/provider.dart';
 
 import '../common/alert_dialogue.dart';
@@ -56,14 +57,29 @@ class _NoteEditorState extends State<NoteEditor> {
 
   String _title = "";
   String _content = "";
+  final int _invalidTagId = -1;
+  int _selectedTagId;
 
   // If note is null, we are creating a new one
   @override
   void initState() {
     super.initState();
+    _selectedTagId = _invalidTagId;
     if (widget.noteModel != null) {
       _title = widget.noteModel.title;
       _content = widget.noteModel.content;
+      _selectedTagId =
+          widget.noteModel.tag == null ? _invalidTagId : widget.noteModel.tag.id;
+    }
+  }
+
+  Future<void> _updateNoteTag(int noteId) async {
+    if (_selectedTagId != _invalidTagId) {
+      print("Try to tie tag $_selectedTagId to note $noteId");
+      await widget.database.tieTagToNote(noteId, _selectedTagId);
+    } else if (_selectedTagId != null) {
+      print("Try to untie tag $_selectedTagId from note $noteId");
+      await widget.database.untieTagFromNote(noteId);
     }
   }
 
@@ -72,13 +88,15 @@ class _NoteEditorState extends State<NoteEditor> {
       try {
         if (widget.noteModel == null) {
           final NoteModel note = NoteModel(title: _title, content: _content);
-          await widget.database.createNote(note);
+          int noteId = await widget.database.createNote(note);
+          await _updateNoteTag(noteId);
         } else {
           final Map<String, dynamic> updatedMap = widget.noteModel.toMap();
           updatedMap["title"] = _title;
           updatedMap["content"] = _content;
 
           await widget.database.updateNote(NoteModel.fromMap(updatedMap));
+          await _updateNoteTag(widget.noteModel.id);
         }
 
         Navigator.of(context).pop();
@@ -146,6 +164,7 @@ class _NoteEditorState extends State<NoteEditor> {
 
   List<Widget> _buildFormChildren() {
     return [
+      _buildTagsDropdown(),
       TextFormField(
         decoration: InputDecoration(labelText: "Note title"),
         initialValue: _title,
@@ -167,5 +186,40 @@ class _NoteEditorState extends State<NoteEditor> {
         onSaved: (value) => _content = value,
       ),
     ];
+  }
+
+  Widget _buildTagsDropdown() {
+    return FutureBuilder<List<TagModel>>(
+        future: widget.database.listTags(),
+        builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
+          if (snapshot.hasData) {
+            final List<TagModel> items = snapshot.data;
+            if (items.isNotEmpty) {
+              List<DropdownMenuItem<int>> dropItems =
+                  items.map<DropdownMenuItem<int>>((TagModel tag) {
+                return DropdownMenuItem(
+                  child: Text(tag.name),
+                  value: tag.id,
+                );
+              }).toList();
+              dropItems.insert(0, DropdownMenuItem(
+                child: Text("No tag"),
+                value: _invalidTagId,
+              ));
+              return DropdownButton(
+                  items: dropItems,
+                  value: _selectedTagId,
+                  onChanged: (int newSelectedValue) {
+                    setState(() {
+                      _selectedTagId = newSelectedValue;
+                    });
+                  });
+            } else {
+              return Text("No tags");
+            }
+          } else {
+            return CircularProgressIndicator();
+          }
+        });
   }
 }

--- a/lib/pages/notes_page.dart
+++ b/lib/pages/notes_page.dart
@@ -79,6 +79,7 @@ class _NotesPageState extends State<NotesPage> {
                       onTap: () => print("Note ${items[index].id} selected"),
                       child: Column(
                         children: <Widget>[
+                          Row(children: _buildTagName(items[index])),
                           Text(
                             items[index].title,
                             style: TextStyle(fontWeight: FontWeight.bold),
@@ -127,5 +128,17 @@ class _NotesPageState extends State<NotesPage> {
         }
       },
     );
+  }
+
+  List<Widget> _buildTagName(NoteModel noteModel) {
+    if (noteModel.tag == null)
+      return [
+        Text("")
+      ];
+    else
+      return [
+        Icon(Icons.tag),
+        Text(noteModel.tag.name)
+      ];
   }
 }

--- a/lib/pages/notes_page.dart
+++ b/lib/pages/notes_page.dart
@@ -25,10 +25,10 @@ import '../models/note_model.dart';
 import '../services/database.dart';
 import 'note_editor.dart';
 
-class MainPage extends StatefulWidget {
+class NotesPage extends StatefulWidget {
   final Database database;
 
-  const MainPage({Key key, this.database}) : super(key: key);
+  const NotesPage({Key key, this.database}) : super(key: key);
 
   static Future<void> show(BuildContext context, {Database database}) async {
     database = (database == null)
@@ -36,17 +36,17 @@ class MainPage extends StatefulWidget {
         : database;
     await Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => MainPage(database: database),
+        builder: (context) => NotesPage(database: database),
         fullscreenDialog: true,
       ),
     );
   }
 
   @override
-  _MainPageState createState() => _MainPageState();
+  _NotesPageState createState() => _NotesPageState();
 }
 
-class _MainPageState extends State<MainPage> {
+class _NotesPageState extends State<NotesPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/pages/tag_editor.dart
+++ b/lib/pages/tag_editor.dart
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/*
+    Copyright (C) 2021  Equipe EmptyCoffeeCups
+
+    This file is part of NotoriousNote.
+
+    NotoriousNote is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    NotoriousNote is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with NotoriousNote.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import 'package:flutter/material.dart';
+import 'package:notorious_note/models/tag_model.dart';
+import 'package:provider/provider.dart';
+
+import '../common/alert_dialogue.dart';
+import '../services/database.dart';
+
+class TagEditor extends StatefulWidget {
+  final Database database;
+  final TagModel tagModel;
+
+  const TagEditor({Key key, this.database, this.tagModel}) : super(key: key);
+
+  static Future<void> show(BuildContext context,
+      {Database database, TagModel tagModel}) async {
+    database = (database == null)
+        ? Provider.of<Database>(context, listen: false)
+        : database;
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) =>
+            TagEditor(database: database, tagModel: tagModel),
+        fullscreenDialog: true,
+      ),
+    );
+  }
+
+  @override
+  _TagEditorState createState() => _TagEditorState();
+}
+
+class _TagEditorState extends State<TagEditor> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  bool validForm() => _name.isNotEmpty;
+
+  String _name = "";
+
+  // If note is null, we are creating a new one
+  @override
+  void initState() {
+    super.initState();
+    if (widget.tagModel != null) {
+      _name = widget.tagModel.name;
+    }
+  }
+
+  Future<void> _submit() async {
+    if (_validateAndSaveForm()) {
+      try {
+        if (widget.tagModel == null) {
+          final TagModel tag = TagModel(name: _name);
+          await widget.database.createTag(tag);
+        } else {
+          final Map<String, dynamic> updatedMap = widget.tagModel.toMap();
+          updatedMap["name"] = _name;
+
+          await widget.database.updateTag(TagModel.fromMap(updatedMap));
+        }
+
+        Navigator.of(context).pop();
+      } catch (e) {
+        print(e);
+        CustomAlertDialogue(
+          title: "Error",
+          content: e.toString(),
+          defaultActionText: "OK",
+        ).show(context);
+      }
+    }
+  }
+
+  bool _validateAndSaveForm() {
+    final FormState form = _formKey.currentState;
+    if (form.validate()) {
+      form.save();
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.tagModel == null ? "New tag" : "Edit tag"),
+        actions: <Widget>[
+          TextButton(
+              onPressed: _submit,
+              child: Text(
+                "Save",
+                style: TextStyle(color: Colors.white),
+              ))
+        ],
+      ),
+      body: _buildContents(),
+    );
+  }
+
+  Widget _buildContents() {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: EdgeInsets.all(16.0),
+        child: Card(
+          child: Padding(
+            padding: EdgeInsets.all(16.0),
+            child: _buildForm(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: _buildFormChildren(),
+      ),
+    );
+  }
+
+  List<Widget> _buildFormChildren() {
+    return [
+      TextFormField(
+        decoration: InputDecoration(labelText: "Tag name"),
+        initialValue: _name,
+        validator: (value) {
+          _name = value;
+          return validForm() ? null : "Name can't be empty";
+        },
+        autovalidateMode: AutovalidateMode.always,
+        onSaved: (value) => _name = value,
+      ),
+    ];
+  }
+}

--- a/lib/pages/tags_page.dart
+++ b/lib/pages/tags_page.dart
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/*
+    Copyright (C) 2021  Equipe EmptyCoffeeCups
+
+    This file is part of NotoriousNote.
+
+    NotoriousNote is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    NotoriousNote is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with NotoriousNote.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import 'package:flutter/material.dart';
+import 'package:notorious_note/models/tag_model.dart';
+import 'package:provider/provider.dart';
+
+import '../services/database.dart';
+import 'tag_editor.dart';
+
+class TagsPage extends StatefulWidget {
+  final Database database;
+
+  const TagsPage({Key key, this.database}) : super(key: key);
+
+  static Future<void> show(BuildContext context, {Database database}) async {
+    database = (database == null)
+        ? Provider.of<Database>(context, listen: false)
+        : database;
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => TagsPage(database: database),
+        fullscreenDialog: true,
+      ),
+    );
+  }
+
+  @override
+  _TagsPageState createState() => _TagsPageState();
+}
+
+class _TagsPageState extends State<TagsPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: _buildContents(context),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await TagEditor.show(context);
+          setState(() {});
+        },
+        tooltip: "New tag",
+        child: Icon(Icons.add),
+      ),
+    );
+  }
+
+  Widget _buildContents(BuildContext context) {
+    return FutureBuilder<List<TagModel>>(
+      future: widget.database.listTags(),
+      builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
+        if (snapshot.hasData) {
+          final List<TagModel> items = snapshot.data;
+          if (items.isNotEmpty) {
+            return ListView.separated(
+                itemBuilder: (context, index) => Card(
+                    child: InkWell(
+                      splashColor: Colors.grey,
+                      onTap: () => print("Tag ${items[index].id} selected"),
+                      child: Column(
+                        children: <Widget>[
+                          Text(
+                            items[index].name,
+                            style: TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              IconButton(
+                                  icon: Icon(Icons.delete),
+                                  onPressed: () async {
+                                    await widget.database
+                                        .deleteTag(items[index].id);
+                                    setState(() {});
+                                  }),
+                              IconButton(
+                                  icon: Icon(Icons.archive), onPressed: null),
+                              IconButton(
+                                  icon: Icon(Icons.edit),
+                                  onPressed: () async {
+                                    await TagEditor.show(context,
+                                        tagModel: items[index]);
+                                    setState(() {});
+                                  })
+                            ],
+                          )
+                        ],
+                      ),
+                    )),
+                separatorBuilder: (context, index) => Divider(
+                  height: 0.5,
+                ),
+                itemCount: items.length);
+          } else {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[Text("No tags"), Text("Please add a tag")],
+              ),
+            );
+          }
+        } else if (snapshot.hasError) {
+          return Center(child: Text(snapshot.error.toString()));
+        } else {
+          return CircularProgressIndicator();
+        }
+      },
+    );
+  }
+}

--- a/lib/pages/tags_page.dart
+++ b/lib/pages/tags_page.dart
@@ -94,8 +94,6 @@ class _TagsPageState extends State<TagsPage> {
                                     setState(() {});
                                   }),
                               IconButton(
-                                  icon: Icon(Icons.archive), onPressed: null),
-                              IconButton(
                                   icon: Icon(Icons.edit),
                                   onPressed: () async {
                                     await TagEditor.show(context,

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -24,20 +24,21 @@ import '../models/tag_model.dart';
 abstract class Database {
   Future<int> init();
 
-  Future<void> createNote(NoteModel noteModel);
+  Future<int> createNote(NoteModel noteModel);
   Future<NoteModel> readNote(int id);
   Future<void> updateNote(NoteModel noteModel);
   Future<void> deleteNote(int id);
 
   Future<List<NoteModel>> listNotes();
 
-  Future<void> createTag(TagModel tagModel);
+  Future<int> createTag(TagModel tagModel);
   Future<TagModel> readTag(int id);
   Future<void> updateTag(TagModel tagModel);
   Future<void> deleteTag(int id);
 
   Future<List<TagModel>> listTags();
 
-  Future<void> tieTagToNote();
-  Future<void> getTagsFromNote();
+  Future<void> tieTagToNote(int noteId, int tagId);
+  Future<void> untieTagFromNote(int noteId);
+  Future<TagModel> getTagFromNote(int noteId);
 }

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -30,6 +30,7 @@ abstract class Database {
   Future<void> deleteNote(int id);
 
   Future<List<NoteModel>> listNotes();
+  Future<List<NoteModel>> listArchivedNotes();
 
   Future<int> createTag(TagModel tagModel);
   Future<TagModel> readTag(int id);

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -32,9 +32,9 @@ abstract class Database {
   Future<List<NoteModel>> listNotes();
 
   Future<void> createTag(TagModel tagModel);
-  Future<TagModel> readTag();
-  Future<void> updateTag();
-  Future<void> deleteTag();
+  Future<TagModel> readTag(int id);
+  Future<void> updateTag(TagModel tagModel);
+  Future<void> deleteTag(int id);
 
   Future<List<TagModel>> listTags();
 

--- a/lib/services/sqlite_database.dart
+++ b/lib/services/sqlite_database.dart
@@ -106,20 +106,39 @@ CREATE TABLE IF NOT EXISTS note_tags(
   }
 
   @override
-  Future<void> deleteTag() {
-    // TODO: implement deleteTag
-    throw UnimplementedError();
+  Future<void> createTag(TagModel tagModel) async {
+      Map<String, dynamic> tagMap = tagModel.toMap();
+      tagMap.remove("id");
+      print("try to insert $tagMap");
+      await db.insert("tags", tagMap);
+  }
+
+  @override
+  Future<TagModel> readTag(int id) async {
+    final List<Map<String, Object>> result =
+        await db.query("tags", where: "id = ?", whereArgs: [id]);
+    if (result.isEmpty)
+      return null;
+    else
+      return TagModel.fromMap(result[0]);
+  }
+
+  @override
+  Future<void> updateTag(TagModel tagModel) async {
+    Map<String, dynamic> tagMap = tagModel.toMap();
+    print("try to insert $tagMap");
+    await db
+        .update("tags", tagMap, where: "id = ?", whereArgs: [tagModel.id]);
+  }
+
+  @override
+  Future<void> deleteTag(int id) async {
+    await db.delete("tags", where: "id = ?", whereArgs: [id]);
   }
 
   @override
   Future<void> getTagsFromNote() {
     // TODO: implement getTagsFromNote
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> createTag(TagModel tagModel) {
-    // TODO: implement createTag
     throw UnimplementedError();
   }
 
@@ -134,15 +153,13 @@ CREATE TABLE IF NOT EXISTS note_tags(
   }
 
   @override
-  Future<List<TagModel>> listTags() {
-    // TODO: implement listTags
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<TagModel> readTag() {
-    // TODO: implement readTag
-    throw UnimplementedError();
+  Future<List<TagModel>> listTags() async {
+    List<Map<String, dynamic>> results =
+        await db.rawQuery("SELECT * FROM tags");
+    print("Tags $results");
+    return results
+        .map((Map<String, dynamic> map) => TagModel.fromMap(map))
+        .toList();
   }
 
   @override
@@ -151,9 +168,5 @@ CREATE TABLE IF NOT EXISTS note_tags(
     throw UnimplementedError();
   }
 
-  @override
-  Future<void> updateTag() {
-    // TODO: implement updateTag
-    throw UnimplementedError();
-  }
+
 }

--- a/lib/services/sqlite_database.dart
+++ b/lib/services/sqlite_database.dart
@@ -138,7 +138,23 @@ CREATE TABLE IF NOT EXISTS note_tags(
   @override
   Future<List<NoteModel>> listNotes() async {
     List<Map<String, dynamic>> results =
-        await db.rawQuery("SELECT * FROM notes");
+        await db.rawQuery("SELECT * FROM notes WHERE archived = ?", [0]);
+    List<NoteModel> notes = results
+        .map((Map<String, dynamic> map) => NoteModel.fromMap(map))
+        .toList();
+    for (var i = 0; i < notes.length; i++) {
+      TagModel tagModel = await getTagFromNote(notes[i].id);
+      if (tagModel != null) {
+        notes[i] = notes[i].copyWith(tag: tagModel);
+      }
+    }
+    return notes;
+  }
+
+  @override
+  Future<List<NoteModel>> listArchivedNotes() async {
+    List<Map<String, dynamic>> results =
+        await db.rawQuery("SELECT * FROM notes WHERE archived = ?", [1]);
     List<NoteModel> notes = results
         .map((Map<String, dynamic> map) => NoteModel.fromMap(map))
         .toList();


### PR DESCRIPTION
Adicionar funcionalidade de criação, leitura, modificação e remoção de
etiquetas.

- Atualizar classe que interage com o banco de dados, implementando os
métodos que trabalham no CRUD de etiquetas e na construção de lista de
- etiquetas existentes
- Renomear página de leitura de notas `MainPage` para `NotesPage`
- Criar página responsável por editar etiquetas
- Modificar classe genérica do banco de dados
- Adicionar página de visualização de etiquetas à página inicial
- Adicionar funcionalidades de criação, modificação e remoção de etiquetas
à página de visualização de etiquetas